### PR TITLE
Make correction to docker image URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example usage:
 
 ```shell
 docker run --name puppet --hostname puppet -v ./code:/etc/puppetlabs/code/ ghcr.io/voxpupuli/container-puppetserver:7.13.0-v1.1.3
-docker run --link postgres:postgres --link puppet:puppet ghcr.io/voxpupuli/puppetdb:7.13.0-v1.2.1
+docker run --link postgres:postgres --link puppet:puppet ghcr.io/voxpupuli/container-puppetdb:7.16.0-v1.3.0
 ```
 
 | Name | Description |


### PR DESCRIPTION
The URL to the puppetdb Docker image referenced in the README.md is no longer valid as the image tag doesn't exist in the Github container repository.

I have updated the README.md to reflect a newer version but not the latest version of the Docker image.