### PR TITLE
feat: enable renovate automerge and add reviewers from codeowners

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "addLabels": ["renovate", "dependencies"],
+  "assigneesFromCodeOwners": true,
+  "dependencyDashboard": true,
+  "automerge": true,
+  "automergeType": "pr"
 }


### PR DESCRIPTION
renovate will enable automerge on all new PRs. PRs still need to be approved by codeowners, and will automatically be merge after approval.