### PR TITLE
fix: Add healthcheck for openvox/puppet and openvoxdb/puppetdb services

### DIFF
--- a/openvox/minimal/compose.yaml
+++ b/openvox/minimal/compose.yaml
@@ -8,11 +8,21 @@ services:
     restart: always
     ports:
       - 8140:8140
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://puppet:8140/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   openvoxdb:
     image: ghcr.io/openvoxproject/openvoxdb:latest
     hostname: openvoxdb
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://openvoxdb:8081/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
       openvoxserver:
         condition: service_healthy

--- a/openvox/oss/compose.yaml
+++ b/openvox/oss/compose.yaml
@@ -16,6 +16,11 @@ services:
     restart: always
     ports:
       - 8140:8140
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://puppet:8140/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     profiles:
       - openvox
 
@@ -29,6 +34,11 @@ services:
       openvoxserver:
         condition: service_healthy
         restart: true
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://openvoxdb:8081/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
       - 8081:8081
     profiles:

--- a/puppet/minimal/compose.yaml
+++ b/puppet/minimal/compose.yaml
@@ -13,6 +13,11 @@ services:
     restart: always
     ports:
       - 8140:8140
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://puppet:8140/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   puppetdb:
     image: ghcr.io/voxpupuli/puppetdb:8.8.1-latest
@@ -26,6 +31,11 @@ services:
       PUPPETDB_POSTGRES_PORT: 5432
       PUPPETDB_PASSWORD: puppetdb
       PUPPETDB_USER: puppetdb
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://puppetdb:8081/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: always
 
   postgres:

--- a/puppet/oss/compose.yaml
+++ b/puppet/oss/compose.yaml
@@ -21,6 +21,11 @@ services:
     restart: always
     ports:
       - 8140:8140
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://puppet:8140/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     profiles:
       - puppet
 
@@ -41,6 +46,11 @@ services:
     restart: always
     ports:
       - 8081:8081
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ksS https://puppetdb:8081/status/v1/simple | grep -q '^running$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     profiles:
       - puppet
 


### PR DESCRIPTION
This pull request introduces health checks for the main service containers in all `compose.yaml` files across the `openvox` and `puppet` projects. These health checks ensure that services like `openvox` / `puppet` and `openvoxdb` / `puppetdb` are running and responsive before dependent services start or restart, improving reliability and orchestration in Docker Compose setups.

Especially this PR fixes the Podman issue described in https://github.com/voxpupuli/crafty/issues/106.