### PR TITLE
feat(iac-with-observability): add Dockerfiles for vmagent and webserver

### DIFF
--- a/openvox/iac-with-oberservability/compose.yaml
+++ b/openvox/iac-with-oberservability/compose.yaml
@@ -59,7 +59,10 @@ services:
 
   # Apache web server 1 with apache_exporter
   webserver1:
-    image: ubuntu:24.04
+    build:
+      context: .
+      dockerfile: ./scripts/webserver.Dockerfile
+    image: iac-webserver1:ubuntu24
     container_name: webserver1
     hostname: webserver1.local
     depends_on:
@@ -67,13 +70,13 @@ services:
         condition: service_healthy
     ports:
       - "9001:80"      # Apache
-    volumes:
-      - ./scripts/webserver-entrypoint.sh:/entrypoint.sh
-    command: bash /entrypoint.sh
 
   # Apache web server 2 with apache_exporter
 #  webserver2:
-#    image: ubuntu:24.04
+#    build:
+#      context: .
+#      dockerfile: ./scripts/webserver.Dockerfile
+#    image: iac-webserver1:ubuntu24
 #    container_name: webserver2
 #    hostname: webserver2.local
 #    depends_on:
@@ -81,13 +84,13 @@ services:
 #        condition: service_healthy
 #    ports:
 #      - "9002:80"      # Apache
-#    volumes:
-#      - ./scripts/webserver-entrypoint.sh:/entrypoint.sh
-#    command: bash /entrypoint.sh
 
   # Apache web server 3 with apache_exporter
 #  webserver3:
-#    image: ubuntu:24.04
+#    build:
+#      context: .
+#      dockerfile: ./scripts/webserver.Dockerfile
+#    image: iac-webserver1:ubuntu24
 #    container_name: webserver3
 #    hostname: webserver3.local
 #    depends_on:
@@ -95,9 +98,6 @@ services:
 #        condition: service_healthy
 #    ports:
 #      - "9003:80"      # Apache
-#    volumes:
-#      - ./scripts/webserver-entrypoint.sh:/entrypoint.sh
-#    command: bash /entrypoint.sh
 
   victoria-metrics:
     image: victoriametrics/victoria-metrics:latest
@@ -122,17 +122,18 @@ services:
         condition: service_healthy
 
   vmagent:
-    image: alpine:latest
+    build:
+      context: .
+      dockerfile: ./scripts/vmagent.Dockerfile
+    image: iac-vmagent:alpine
     container_name: vmagent
     hostname: vmagent.local
     ports:
       - "8429:8429"
     volumes:
-      - ./scripts/vmagent-entrypoint.sh:/entrypoint.sh
       - ./prometheus-vmagent.yaml:/etc/prometheus/prometheus.yaml
       - vmagent-data:/vmagentdata
       - vmagent-targets:/etc/vmagent/targets.d
-    command: sh /entrypoint.sh
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8429/-/healthy >/dev/null"]
       start_period: 30s

--- a/openvox/iac-with-oberservability/scripts/vmagent-entrypoint.sh
+++ b/openvox/iac-with-oberservability/scripts/vmagent-entrypoint.sh
@@ -2,13 +2,6 @@
 
 set -eu -o pipefail
 
-# Install required packages
-apk update
-apk add --no-cache curl tar ruby ruby-dev ruby-racc ruby-syslog shadow util-linux build-base
-
-# openvox-agent has no Alpine package; install openvox gem (compatible with OpenVox server)
-gem install openvox --no-document
-
 mkdir -p /etc/puppetlabs/puppet
 touch /etc/puppetlabs/puppet/puppet.conf
 

--- a/openvox/iac-with-oberservability/scripts/vmagent.Dockerfile
+++ b/openvox/iac-with-oberservability/scripts/vmagent.Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:latest
+
+# Install runtime/build dependencies and OpenVox client once at image build time.
+RUN apk add --no-cache \
+    curl \
+    tar \
+    ruby \
+    ruby-dev \
+    ruby-racc \
+    ruby-syslog \
+    shadow \
+    util-linux \
+    build-base \
+  && gem install --no-document openvox
+
+COPY ./scripts/vmagent-entrypoint.sh /usr/local/bin/vmagent-entrypoint.sh
+RUN chmod +x /usr/local/bin/vmagent-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/vmagent-entrypoint.sh"]

--- a/openvox/iac-with-oberservability/scripts/webserver-entrypoint.sh
+++ b/openvox/iac-with-oberservability/scripts/webserver-entrypoint.sh
@@ -2,14 +2,6 @@
 
 set -eou pipefail
 
-export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get install -y curl
-curl -LR https://apt.voxpupuli.org/openvox8-release-ubuntu24.04.deb -o /tmp/openvox8-release-ubuntu24.04.deb
-dpkg -i /tmp/openvox8-release-ubuntu24.04.deb
-apt-get update
-apt-get install -y openvox-agent
-
 /opt/puppetlabs/bin/puppet config set server puppet --section main
 /opt/puppetlabs/bin/puppet config set runinterval 60 --section main
 

--- a/openvox/iac-with-oberservability/scripts/webserver.Dockerfile
+++ b/openvox/iac-with-oberservability/scripts/webserver.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install OpenVox agent and Apache once at image build time.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl ca-certificates \
+  && curl -LR https://apt.voxpupuli.org/openvox8-release-ubuntu24.04.deb -o /tmp/openvox8-release-ubuntu24.04.deb \
+  && dpkg -i /tmp/openvox8-release-ubuntu24.04.deb \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends openvox-agent apache2 \
+  && rm -rf /var/lib/apt/lists/* /tmp/openvox8-release-ubuntu24.04.deb
+
+COPY ./scripts/webserver-entrypoint.sh /usr/local/bin/webserver-entrypoint.sh
+RUN chmod +x /usr/local/bin/webserver-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/webserver-entrypoint.sh"]


### PR DESCRIPTION
Move entrypoint logic into dedicated Dockerfiles for vmagent and webserver, and update compose.yaml accordingly.